### PR TITLE
adding POST /keyboard?type=<type>

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,9 @@ Shows keyboard
 **DELETE /keyboard**
 
 Hides keyboard
+
+**POST /keyboard?type=&lt;type&gt;**
+
+Submits a keyboard action.
+
+Some actions may not be available on all platforms. See [TextInputAction](https://api.flutter.dev/flutter/services/TextInputAction-class.html) for more information.

--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -125,7 +125,7 @@ class _Driver {
       return;
     }
 
-    _textInputDriver.submit(type);
+    _textInputDriver.keyboardAction(type);
   }
 
   Future<void> _getWidgets(AutopilotAction action) async {

--- a/lib/src/driver.dart
+++ b/lib/src/driver.dart
@@ -104,8 +104,28 @@ class _Driver {
       SystemChannels.textInput.invokeMethod("TextInput.show");
     } else if (action.request.method == "DELETE") {
       SystemChannels.textInput.invokeMethod("TextInput.hide");
+    } else if (action.request.method == "POST") {
+      _handleKeyboardAction(action);
     }
     action.response.close();
+  }
+
+  String get _acceptableValuesMsg =>
+      'Acceptable values are: [${_textInputDriver.submitTypes.keys.join(', ')}]';
+
+  Future<void> _handleKeyboardAction(AutopilotAction action) async {
+    final params = action.request.uri.queryParameters;
+    final acceptableTypes = _textInputDriver.submitTypes.keys;
+    final type = params['type'];
+    if (type == null || !acceptableTypes.contains(type)) {
+      action.sendError(
+          Exception(
+              "Type '$type' is not an available action. $_acceptableValuesMsg"),
+          StackTrace.current);
+      return;
+    }
+
+    _textInputDriver.submit(type);
   }
 
   Future<void> _getWidgets(AutopilotAction action) async {

--- a/lib/src/text_input.dart
+++ b/lib/src/text_input.dart
@@ -8,7 +8,7 @@ class TextInputDriver {
     SystemChannels.textInput.setMockMethodCallHandler(_handler);
   }
 
-  void _handlePlatformMessage(String methodName, dynamic arguments) {
+  void _handlePlatformMessage(String methodName, List<dynamic> arguments) {
     ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
       SystemChannels.textInput.name,
       SystemChannels.textInput.codec.encodeMethodCall(

--- a/lib/src/text_input.dart
+++ b/lib/src/text_input.dart
@@ -8,19 +8,45 @@ class TextInputDriver {
     SystemChannels.textInput.setMockMethodCallHandler(_handler);
   }
 
-  void type(String text) {
-    var value = TextEditingValue(text: text);
+  void _handlePlatformMessage(String methodName, dynamic arguments) {
     ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
       SystemChannels.textInput.name,
       SystemChannels.textInput.codec.encodeMethodCall(
         MethodCall(
-          'TextInputClient.updateEditingState',
-          <dynamic>[_clientId, value.toJSON()],
+          methodName,
+          arguments,
         ),
       ),
       (ByteData data) {},
     );
   }
+
+  void type(String text) {
+    var value = TextEditingValue(text: text);
+    _handlePlatformMessage('TextInputClient.updateEditingState',
+        <dynamic>[_clientId, value.toJSON()]);
+  }
+
+  void submit(String type) {
+    _handlePlatformMessage('TextInputClient.performAction',
+        <dynamic>[_clientId, submitTypes[type].toString()]);
+  }
+
+  Map<String, TextInputAction> get submitTypes => {
+        'continueAction': TextInputAction.continueAction,
+        'done': TextInputAction.done,
+        'emergencyCall': TextInputAction.emergencyCall,
+        'go': TextInputAction.go,
+        'join': TextInputAction.join,
+        'newline': TextInputAction.newline,
+        'next': TextInputAction.next,
+        'none': TextInputAction.none,
+        'previous': TextInputAction.previous,
+        'route': TextInputAction.route,
+        'search': TextInputAction.search,
+        'send': TextInputAction.send,
+        'unspecified': TextInputAction.unspecified,
+      };
 
   Future<dynamic> _handler(MethodCall methodCall) async {
     ui.window.sendPlatformMessage(

--- a/lib/src/text_input.dart
+++ b/lib/src/text_input.dart
@@ -8,19 +8,45 @@ class TextInputDriver {
     SystemChannels.textInput.setMockMethodCallHandler(_handler);
   }
 
-  void type(String text) {
-    var value = TextEditingValue(text: text);
+  void _handlePlatformMessage(String methodName, dynamic arguments) {
     ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
       SystemChannels.textInput.name,
       SystemChannels.textInput.codec.encodeMethodCall(
         MethodCall(
-          'TextInputClient.updateEditingState',
-          <dynamic>[_clientId, value.toJSON()],
+          methodName,
+          arguments,
         ),
       ),
       (ByteData data) {},
     );
   }
+
+  void type(String text) {
+    final value = TextEditingValue(text: text);
+    _handlePlatformMessage('TextInputClient.updateEditingState',
+        <dynamic>[_clientId, value.toJSON()]);
+  }
+
+  void submit(String type) {
+    _handlePlatformMessage('TextInputClient.performAction',
+        <dynamic>[_clientId, submitTypes[type].toString()]);
+  }
+
+  Map<String, TextInputAction> get submitTypes => {
+        'continueAction': TextInputAction.continueAction,
+        'done': TextInputAction.done,
+        'emergencyCall': TextInputAction.emergencyCall,
+        'go': TextInputAction.go,
+        'join': TextInputAction.join,
+        'newline': TextInputAction.newline,
+        'next': TextInputAction.next,
+        'none': TextInputAction.none,
+        'previous': TextInputAction.previous,
+        'route': TextInputAction.route,
+        'search': TextInputAction.search,
+        'send': TextInputAction.send,
+        'unspecified': TextInputAction.unspecified,
+      };
 
   Future<dynamic> _handler(MethodCall methodCall) async {
     ui.window.sendPlatformMessage(

--- a/lib/src/text_input.dart
+++ b/lib/src/text_input.dart
@@ -27,7 +27,7 @@ class TextInputDriver {
         <dynamic>[_clientId, value.toJSON()]);
   }
 
-  void submit(String type) {
+  void keyboardAction(String type) {
     _handlePlatformMessage('TextInputClient.performAction',
         <dynamic>[_clientId, submitTypes[type].toString()]);
   }


### PR DESCRIPTION
I added in all the current supported actions from [here](https://api.flutter.dev/flutter/services/TextInputAction-class.html). Some of them aren't available on all platforms. Wasn't sure how you might want to handle that (or if we want to at this point). 

Pull Request for #3